### PR TITLE
report 0 if a certain protocol is not used

### DIFF
--- a/updater/reports/ReportGitProtocol.py
+++ b/updater/reports/ReportGitProtocol.py
@@ -17,8 +17,8 @@ class ReportGitProtocol(ReportDaily):
 		self.data.append(
 			[
 				str(self.yesterday()),
-				protocols["http"],
-				protocols["ssh"],
+				protocols.get("http", 0),
+				protocols.get("ssh", 0),
 			])
 		self.truncateData(self.timeRangeTotal())
 		self.sortDataByDate()


### PR DESCRIPTION
If a protocol is not used, then we see no log lines about it. Therefore,
the existing code would throw a `KeyError` if we query the numbers from
the dictionary.

Fix this by using a default value.